### PR TITLE
Add image credits

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
   <script src="quiz.js"></script>
   <script>
     $(function() {
-      $('#quiz').quiz("tpc.json");
+      $('#quiz').quiz("unicorns.json");
     });
   </script>
 </body>

--- a/quiz.css
+++ b/quiz.css
@@ -76,6 +76,14 @@ html, body {
   margin-top: 20px;
 
 }
+.image-credit {
+  font-size: 12px;
+  color: #696969;
+  font-weight: 400;
+  text-align: right;
+  max-width: 1100px;
+  margin: 0 auto;
+}
 .results-social{
  display: table;
 }
@@ -128,7 +136,7 @@ html, body {
 }
 
 .show{
- display:table !important; 
+ display:table !important;
 }
 
 .progress-circles li{
@@ -154,7 +162,7 @@ html, body {
   width: 32px;
 }
 .follow-tw:hover{
- background-position: 0 -1401px;   
+ background-position: 0 -1401px;
 }
 .follow-fb {
   display: inline-block;
@@ -165,7 +173,7 @@ html, body {
   width: 32px;
 }
 .follow-fb:hover{
- background-position: 0 -1433px;   
+ background-position: 0 -1433px;
 }
 
 

--- a/quiz.js
+++ b/quiz.js
@@ -98,7 +98,7 @@ var $indicators = $('<ol>')
 
     })
     .appendTo($start_button);
-  
+
   $indicators
     .appendTo($quiz);
 
@@ -127,6 +127,10 @@ var $indicators = $('<ol>')
       $("<img>")
         .attr("class", "img-responsive")
         .attr("src", question.image)
+        .appendTo($img_div);
+      $('<p>')
+        .text(question.image_credit)
+        .attr("class", "image-credit")
         .appendTo($img_div);
     }
     $("<div>")

--- a/quiz_questions.py
+++ b/quiz_questions.py
@@ -17,6 +17,8 @@ q_rx = re.compile(r"""
   (?P<answers>(?:\s+[-\*]\s.+)+)
   # image to include in response
   \s+(?P<image>\(image\).+)?
+  # credits to the image included in response
+  \s+(?P<image_credit>\(image_credit\).+)?
   # Extra text to include in response
   \s+(?P<text>(?![-\*]|^\d+\)|\s+\(image\)).+)?
 """, re.X | re.M)
@@ -68,6 +70,9 @@ def toJson(filename):
 
     if q['image']:
       out['image'] = q['image'].replace('(image)', "").strip()
+      
+    if q['image_credit']:
+      out['image_credit'] = q['image_credit'].replace('(image_credit)', "").strip()
 
     # correct answer info
     out['correct'] = {}

--- a/unicorns.json
+++ b/unicorns.json
@@ -16,8 +16,7 @@
     },
     {
       "answers": [
-        "True",
-        "False"
+        "True"
       ],
       "correct": {
         "index": 0
@@ -35,6 +34,7 @@
         "index": 1
       },
       "image": "unicorn.jpg",
+      "image_credit": "Random dude from the Interwebs",
       "number": 3,
       "prompt": "What shade of white is this unicorn?"
     }

--- a/unicorns.quiz
+++ b/unicorns.quiz
@@ -37,5 +37,9 @@ url: http://urbaninstitute.github.io/quick-quiz/
   - Egg shell
 
   // this image will appear along with
-  // the question pompt
+  // the question prompt
   (image) unicorn.jpg
+
+  // this credit will appear along with
+  // image
+  (image_credit) Random dude from the Interwebs


### PR DESCRIPTION
I had to build out some functionality for the down payments quiz to get image credits to show up with images in the quiz.  I wanted to make sure that code gets included in this repo so others can use this too.  Basically you can specify an `image_credit` field when building out the .quiz file and then the credit will show up below the image.